### PR TITLE
Update header so that the course is 'online'

### DIFF
--- a/index.md
+++ b/index.md
@@ -134,7 +134,7 @@ address.
 {% elsif begin_address contains "http" %}
 {% assign online = "true_public" %}
 {% else %}
-{% assign online = "false" %}
+{% assign online = "true" %}
 {% endif %}
 {% if page.latitude and page.longitude and online == "false" %}
 <p id="where">


### PR DESCRIPTION
There are notes about accessible bathrooms and openstreet maps that are not relevant.
Not sure if I did this right. There's an error further down this page that I want to correct, but I thought I'd try to fix something easier first -- I may have found something harder given that there's lots of code embedded in this opener.